### PR TITLE
removed tag from name

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -60,7 +60,7 @@ jobs:
                - name: Generate Kubernetes manifest
                  shell: pwsh
                  run: |
-                      $app_name = "${{ github.repository }}-${{ github.ref_name }}".Replace("/", "-")
+                      $app_name = "${{ github.repository }}".Replace("/", "-")
                       $app_name | Out-File -FilePath appname.txt
                       $dnsname = "${{ vars.DOMAIN }}"
                       $dnsname | Out-File -FilePath dnsname.txt


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/on-push.yml` file. The change modifies the generation of the Kubernetes manifest by removing the branch name from the `app_name` variable.

* [`.github/workflows/on-push.yml`](diffhunk://#diff-1627952414787bd2f89d526459771a1f2c92a48d7309f7b4e307f81753eedb04L63-R63): Updated the `app_name` variable to exclude the branch name, simplifying the generated name.