### PR TITLE
Canary

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -60,7 +60,7 @@ jobs:
                - name: Generate Kubernetes manifest
                  shell: pwsh
                  run: |
-                      $app_name = "${{ github.repository }}".Replace("/", "-")
+                      $app_name = "${{ github.repository }}-${{ github.ref_name }}".Replace("/", "-").Replace(".", "-")
                       $app_name | Out-File -FilePath appname.txt
                       $dnsname = "${{ vars.DOMAIN }}"
                       $dnsname | Out-File -FilePath dnsname.txt


### PR DESCRIPTION
This pull request includes a change to the `jobs` section in the `.github/workflows/on-push.yml` file to improve the generation of the Kubernetes manifest. 

* Modified the generation of the `$app_name` variable to include the branch name and replace periods with hyphens. This change ensures that the application name is unique per branch and conforms to DNS naming conventions. (`.github/workflows/on-push.yml`)