### PR TITLE
 modification to the DNS name assignment in the `jobs`

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -62,7 +62,7 @@ jobs:
                  run: |
                       $app_name = "${{ github.repository }}-${{ github.ref_name }}".Replace("/", "-").Replace(".", "-")
                       $app_name | Out-File -FilePath appname.txt
-                      $dnsname = "${{ vars.DOMAIN }}"
+                      $dnsname = "$app_name.${{ vars.DOMAIN }}"
                       $dnsname | Out-File -FilePath dnsname.txt
                       @"
                         apiVersion: apps/v1


### PR DESCRIPTION
This pull request includes a modification to the DNS name assignment in the `jobs` section of the `.github/workflows/on-push.yml` file. The change ensures that the DNS name is dynamically generated based on the application name and the domain.

* [`.github/workflows/on-push.yml`](diffhunk://#diff-1627952414787bd2f89d526459771a1f2c92a48d7309f7b4e307f81753eedb04L65-R65): Updated the DNS name assignment to include the application name, ensuring unique DNS names for each deployment.